### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cruft (0.9.40) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + cruft: Drop versioned constraint on cruft-common in Depends.
+    + cruft-common: Drop versioned constraint on cruft in Replaces.
+    + cruft-common: Drop versioned constraint on cruft in Breaks.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 16 Sep 2021 10:19:45 -0000
+
 cruft (0.9.39) unstable; urgency=medium
 
   * update plymouth, systemd, sddm, unattended-upgrades, cups, aptitude,

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Rules-Requires-Root: no
 
 Package: cruft
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, file, cruft-common (>= 0.9.24~)
+Depends: ${shlibs:Depends}, ${misc:Depends}, file, cruft-common
 Suggests: mailx, cruft-ng
 Description: program that finds any cruft built up on your system
  cruft is a program to look over your system for anything that shouldn't
@@ -29,8 +29,6 @@ Description: program that finds any cruft built up on your system
 Package: cruft-common
 Architecture: all
 Depends: ${misc:Depends}
-Breaks: cruft (<< 0.9.24)
-Replaces: cruft (<< 0.9.20)
 Description: information database shared by cruft & cruft-ng
  cruft & cruft-ng are programs to look over your system for anything
  that shouldn't be there, but is; or for anything that should be there,


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/cruft/71cd1c37-c92d-45d3-bc2e-0efccd18201b.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/5e/2be3788b7d62de792aead22517ef6d613ecffe.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6a/a012119cb9854b667dafa69e6f289918286076.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/89/d91b987dbc72a5f114f983aaf4b551edcb78be.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c3/2bd7970dc2d6310e09273d732a65c4fef07a78.debug
### Control files of package cruft: lines which differ (wdiff format)
* Depends: libc6 (>= 2.14), file, cruft-common [-(>= 0.9.24~)-]
### Control files of package cruft-common: lines which differ (wdiff format)
* [-Breaks: cruft (<< 0.9.24)-]
* [-Replaces: cruft (<< 0.9.20)-]
### Control files of package cruft-dbgsym: lines which differ (wdiff format)
* Build-Ids: 574d5b122f35467135abbf849a93d6c1e44d5bd9 {+5e2be3788b7d62de792aead22517ef6d613ecffe 6aa012119cb9854b667dafa69e6f289918286076+} 7a4cf26c3f0d7e6b51e8e700dee7333d74e96594 820c9f151c48140e7057527f70dd63bf2e3c0787 [-89d91b987dbc72a5f114f983aaf4b551edcb78be c32bd7970dc2d6310e09273d732a65c4fef07a78-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/71cd1c37-c92d-45d3-bc2e-0efccd18201b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/71cd1c37-c92d-45d3-bc2e-0efccd18201b/diffoscope)).
